### PR TITLE
Add resolver to proxy configurations

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -3,6 +3,7 @@ server {
 	server_name _;
   location / {
       include /etc/nginx/conf.d/defaults/proxy.conf;
+      resolver 127.0.0.11 valid=10s ipv6=off;
       proxy_pass http://cboard:80;
   }
 }

--- a/nginx/conf.d/proxy-confs/api.subdomain.conf
+++ b/nginx/conf.d/proxy-confs/api.subdomain.conf
@@ -4,6 +4,7 @@ server {
 
   location / {
       include /etc/nginx/conf.d/defaults/proxy.conf;
+      resolver 127.0.0.11 valid=10s ipv6=off;
       proxy_pass http://cboard-api:80;
   }
 }

--- a/nginx/conf.d/proxy-confs/cbuilder.subdomain.conf
+++ b/nginx/conf.d/proxy-confs/cbuilder.subdomain.conf
@@ -10,6 +10,7 @@ server {
 
   location / {
       include /etc/nginx/conf.d/defaults/proxy.conf;
+      resolver 127.0.0.11 valid=10s ipv6=off;
       proxy_pass http://cboard-cbuilder:80;
   }
 }

--- a/nginx/conf.d/proxy-confs/fluidmind.subdomain.conf
+++ b/nginx/conf.d/proxy-confs/fluidmind.subdomain.conf
@@ -10,6 +10,7 @@ server {
 
   location / {
       include /etc/nginx/conf.d/defaults/proxy.conf;
+      resolver 127.0.0.11 valid=10s ipv6=off;
       proxy_pass http://fluid-mind:80;
   }
 }

--- a/nginx/conf.d/proxy-confs/wiki.subdomain.conf
+++ b/nginx/conf.d/proxy-confs/wiki.subdomain.conf
@@ -4,6 +4,7 @@ server {
 
   location / {
       include /etc/nginx/conf.d/defaults/proxy.conf;
+      resolver 127.0.0.11 valid=10s ipv6=off;
       proxy_pass http://cboard-wiki:80;
   }
 }


### PR DESCRIPTION
Introduce a resolver directive with a validity of 10 seconds to all proxy configurations for dynamic upstreams, enhancing DNS resolution reliability.