### PR TITLE
Adds basic authentication to /protected path

### DIFF
--- a/nginx/conf.d/proxy-confs/cbuilder.subdomain.conf
+++ b/nginx/conf.d/proxy-confs/cbuilder.subdomain.conf
@@ -8,7 +8,9 @@ server {
   proxy_send_timeout 2400;
   proxy_connect_timeout 2400;
 
-  location / {
+  location /protected {
+      auth_basic "Restricted Area";
+      auth_basic_user_file /etc/nginx/.htpasswd; # Path inside the container
       include /etc/nginx/conf.d/defaults/proxy.conf;
       proxy_pass http://cboard-cbuilder:80;
   }

--- a/nginx/conf.d/proxy-confs/fluidmind.subdomain.conf
+++ b/nginx/conf.d/proxy-confs/fluidmind.subdomain.conf
@@ -8,7 +8,9 @@ server {
   proxy_send_timeout 2400;
   proxy_connect_timeout 2400;
 
-  location / {
+  location /protected {
+      auth_basic "Restricted Area";
+      auth_basic_user_file /etc/nginx/.htpasswd; # Path inside the container
       include /etc/nginx/conf.d/defaults/proxy.conf;
       proxy_pass http://fluid-mind:80;
   }

--- a/nginx/conf.d/proxy-confs/wiki.subdomain.conf
+++ b/nginx/conf.d/proxy-confs/wiki.subdomain.conf
@@ -2,7 +2,9 @@ server {
   listen              80;
   server_name         wiki.*;
 
-  location / {
+  location /protected {
+      auth_basic "Restricted Area";
+      auth_basic_user_file /etc/nginx/.htpasswd; # Path inside the container
       include /etc/nginx/conf.d/defaults/proxy.conf;
       proxy_pass http://cboard-wiki:80;
   }


### PR DESCRIPTION
Implements basic authentication for the `/protected` location in the Nginx configuration files for cbuilder, fluidmind, and wiki subdomains.

This change restricts access to these locations, requiring users to authenticate using a username and password stored in the `/etc/nginx/.htpasswd` file.
